### PR TITLE
fix: exclude melee weapons from per-weapon ammo display

### DIFF
--- a/src/__tests__/components/unit-card/MachineAmmoPanel.test.tsx
+++ b/src/__tests__/components/unit-card/MachineAmmoPanel.test.tsx
@@ -123,4 +123,76 @@ describe('MachineAmmoPanel', () => {
     const shotsText = screen.getByText(/99/);
     expect(shotsText).toBeInTheDocument();
   });
+
+  describe('melee weapons filtering', () => {
+    it('excludes melee weapons (ББ range) from per-weapon ammo display', () => {
+      const weaponsWithMelee: Weapon[] = [
+        { name: 'Cannon', range: 'D12', power: '2D20' },
+        { name: 'Melee Claw', range: 'ББ', power: '4' }  // Melee weapon
+      ];
+
+      render(
+        <MachineAmmoPanel
+          {...defaultProps}
+          weapons={weaponsWithMelee}
+          weaponAmmo={[15, 10]}
+          usePerWeaponAmmo={true}
+        />
+      );
+
+      // Should show ranged weapon
+      expect(screen.getByText('Cannon')).toBeInTheDocument();
+
+      // Should NOT show melee weapon in ammo panel
+      expect(screen.queryByText('Melee Claw')).not.toBeInTheDocument();
+    });
+
+    it('excludes melee weapons (numeric power) from per-weapon ammo display', () => {
+      const weaponsWithMelee: Weapon[] = [
+        { name: 'MG', range: 'D6', power: '1D12' },
+        { name: 'Crusher', range: 'D6', power: '3' }  // Melee (numeric power)
+      ];
+
+      render(
+        <MachineAmmoPanel
+          {...defaultProps}
+          weapons={weaponsWithMelee}
+          weaponAmmo={[15, 10]}
+          usePerWeaponAmmo={true}
+        />
+      );
+
+      // Should show ranged weapon
+      expect(screen.getByText('MG')).toBeInTheDocument();
+
+      // Should NOT show melee weapon in ammo panel
+      expect(screen.queryByText('Crusher')).not.toBeInTheDocument();
+    });
+
+    it('excludes only melee weapons when mixed', () => {
+      const mixedWeapons: Weapon[] = [
+        { name: 'Cannon', range: 'D12', power: '2D20' },
+        { name: 'MG', range: 'D6', power: '1D12' },
+        { name: 'Melee Claw', range: 'ББ', power: '4' },
+        { name: 'Crusher', range: 'D6', power: '3' }
+      ];
+
+      render(
+        <MachineAmmoPanel
+          {...defaultProps}
+          weapons={mixedWeapons}
+          weaponAmmo={[15, 12, 10, 8]}
+          usePerWeaponAmmo={true}
+        />
+      );
+
+      // Should show ranged weapons only
+      expect(screen.getByText('Cannon')).toBeInTheDocument();
+      expect(screen.getByText('MG')).toBeInTheDocument();
+
+      // Should NOT show melee weapons
+      expect(screen.queryByText('Melee Claw')).not.toBeInTheDocument();
+      expect(screen.queryByText('Crusher')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/cards/unit-card/machine-view/MachineAmmoPanel.tsx
+++ b/src/components/cards/unit-card/machine-view/MachineAmmoPanel.tsx
@@ -2,6 +2,16 @@ import { Bomb, Target, Plus, Minus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Weapon } from '@/lib/types';
 
+// Helper to check if weapon is non-ranged (melee/special) - same logic as MachineWeaponsList
+const isNonRangedWeapon = (weapon: Weapon) => {
+  // Melee range (ББ)
+  if (weapon.range === 'ББ') return true;
+  // Power is a simple number (not dice notation like "2D6")
+  const powerStr = String(weapon.power);
+  if (/^\d+$/.test(powerStr)) return true;
+  return false;
+};
+
 interface MachineAmmoPanelProps {
   currentAmmo: number;
   maxAmmo: number;
@@ -138,7 +148,10 @@ export function MachineAmmoPanel({
       </div>
 
       {/* Per-weapon ammo bars for community_star_system */}
-      {usePerWeaponAmmo && weapons.map((weapon, idx) => {
+      {usePerWeaponAmmo && weapons
+        .map((weapon, idx) => ({ weapon, idx }))
+        .filter(({ weapon }) => !isNonRangedWeapon(weapon))
+        .map(({ weapon, idx }) => {
         const weaponAmmoCount = weaponAmmo?.[idx] ?? weapon.ammo ?? maxAmmo;
         const weaponMaxAmmo = weapon.ammo ?? maxAmmo;
 


### PR DESCRIPTION
Melee weapons (range='ББ' or numeric power) don't use ammo and should not appear in the per-weapon ammo panel. They only belong in the "Ближний бой" (Melee) section at the bottom of the weapons list.